### PR TITLE
Adding the common requirements to the tomtom image

### DIFF
--- a/tomtom/Dockerfile
+++ b/tomtom/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update  && apt-get install -y libglib2.0-dev git autogen autoconf libtool imagemagick zip \
-	wget build-essential gettext cmake \
+	wget build-essential gettext cmake unzip librsvg2-bin util-linux ssh \
 	&& apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN dpkg --add-architecture i386 && apt-get update \
 	&& apt-get install -y libc6:i386 libncurses5:i386 libstdc++6:i386 \


### PR DESCRIPTION
This way we can remove the need to add the `setup_common_requirements.sh` and save time not reinstalling things every time we build.

@pgrandin question that might seem stupid but why do we recompile the libs from scratch instead of using the ones in the repo for tomtom? (like libxml2 or zlib for example)