### PR TITLE
Try and fix the wince build

### DIFF
--- a/wince/Dockerfile
+++ b/wince/Dockerfile
@@ -8,8 +8,10 @@ RUN wget -c http://cfhcable.dl.sourceforge.net/project/cegcc/cegcc/0.59.1/mingw3
 	-O mingw32ce-0.59.1.tar.bz2 --no-check-certificate && tar xvjpf mingw32ce-0.59.1.tar.bz2 \
 	&& rm mingw32ce-0.59.1.tar.bz2
 
-RUN wget http://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-i386.sh --no-check-certificate && \
-	yes | bash /cmake-3.2.0-Linux-i386.sh --prefix /usr/local && rm /cmake-3.2.0-Linux-i386.sh
+# curl and wget both fail to download that on Ubuntu 8.04
+# RUN wget --no-check-certificate https://cmake.org/files/v3.2/cmake-3.2.0-Linux-i386.sh && \
+COPY cmake-3.2.0-Linux-i386.sh /
+RUN yes | bash /cmake-3.2.0-Linux-i386.sh --prefix /usr/local && rm /cmake-3.2.0-Linux-i386.sh
 
 RUN mkdir /var/lib/apt/lists/partial
 ENV MINGW32CE_PATH="/opt/mingw32ce"


### PR DESCRIPTION
The build on wince has been failing for more than 13 days now due to the fact that we have very old version of curl and wget on this image: https://hub.docker.com/r/navit/dockerfiles/builds/

Both curl and wget fail when connecting to cmake probably because the encryption is not supported (even when using insecure, they still need to be able to decrypt the packets).

Anyway, as a temporary solution I downloaded the file we retrieve from the cmake servers (this one won't change anyway).

When we upgrade the base image we can clean that up.

Thanks
Joseph