### PR TITLE
Try to upgrade the wince build image

### DIFF
--- a/wince/Dockerfile
+++ b/wince/Dockerfile
@@ -1,19 +1,23 @@
-FROM navit/ubuntu:8.04
+FROM i386/debian:stable
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget build-essential libmpfr-dev gettext pocketpc-cab \
-	ca-certificates zip ssh librsvg2-bin git-core xsltproc \
+RUN apt-get update \
+# RUN dpkg --add-architecture i386 \
+#     && apt-get update \
+    && apt-get install -y --no-install-recommends wget libmpfr-dev gettext lcab \
+	ca-certificates zip ssh git-core xsltproc \
+    # cmake:i386 build-essential:i386 librsvg2-bin:i386 gcc:i386 binutils:i386 \
+    cmake build-essential librsvg2-bin gcc binutils \
 	 && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN wget http://snapshot.debian.org/archive/debian-archive/20110127T084257Z/debian/pool/main/p/pocketpc-cab/pocketpc-cab_1.0.1-2_all.deb \
+    && dpkg -i pocketpc-cab_1.0.1-2_all.deb \
+    && rm -f pocketpc-cab_1.0.1-2_all.deb
 
 RUN wget -c http://cfhcable.dl.sourceforge.net/project/cegcc/cegcc/0.59.1/mingw32ce-0.59.1.tar.bz2 \
 	-O mingw32ce-0.59.1.tar.bz2 --no-check-certificate && tar xvjpf mingw32ce-0.59.1.tar.bz2 \
 	&& rm mingw32ce-0.59.1.tar.bz2
 
-# curl and wget both fail to download that on Ubuntu 8.04
-# RUN wget --no-check-certificate https://cmake.org/files/v3.2/cmake-3.2.0-Linux-i386.sh && \
-COPY cmake-3.2.0-Linux-i386.sh /
-RUN yes | bash /cmake-3.2.0-Linux-i386.sh --prefix /usr/local && rm /cmake-3.2.0-Linux-i386.sh
-
 RUN mkdir /var/lib/apt/lists/partial
 ENV MINGW32CE_PATH="/opt/mingw32ce"
-ENV PATH=$PATH:$MINGW32CE_PATH/bin:/cmake-3.2.0-Linux-i386/bin/
+ENV PATH=$PATH:$MINGW32CE_PATH/bin
 


### PR DESCRIPTION
Currently the image builds fine, but when I build navit in it I get:
```
-- Check for working C compiler: /opt/mingw32ce/bin/arm-mingw32ce-gcc -- broken
CMake Error at /usr/share/cmake-3.7/Modules/CMakeTestCCompiler.cmake:51 (message):
  The C compiler "/opt/mingw32ce/bin/arm-mingw32ce-gcc" is not able to
  compile a simple test program.

  It fails with the following output:

   Change Dir: /root/project/navit/wince/CMakeFiles/CMakeTmp

  

  Run Build Command:"/usr/bin/make" "cmTC_bc7ff/fast"

  /usr/bin/make -f CMakeFiles/cmTC_bc7ff.dir/build.make
  CMakeFiles/cmTC_bc7ff.dir/build

  make[1]: Entering directory '/root/project/navit/wince/CMakeFiles/CMakeTmp'

  Building C object CMakeFiles/cmTC_bc7ff.dir/testCCompiler.c.obj

  /opt/mingw32ce/bin/arm-mingw32ce-gcc -o
  CMakeFiles/cmTC_bc7ff.dir/testCCompiler.c.obj -c
  /root/project/navit/wince/CMakeFiles/CMakeTmp/testCCompiler.c

  /opt/mingw32ce/libexec/gcc/arm-mingw32ce/4.4.0/cc1: error while loading
  shared libraries: libmpfr.so.1: cannot open shared object file: No such
  file or directory

  CMakeFiles/cmTC_bc7ff.dir/build.make:65: recipe for target
  'CMakeFiles/cmTC_bc7ff.dir/testCCompiler.c.obj' failed

  make[1]: *** [CMakeFiles/cmTC_bc7ff.dir/testCCompiler.c.obj] Error 1

  make[1]: Leaving directory '/root/project/navit/wince/CMakeFiles/CMakeTmp'

  Makefile:126: recipe for target 'cmTC_bc7ff/fast' failed

  make: *** [cmTC_bc7ff/fast] Error 2

  

  

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:4 (project)
```

Pushing it there to see if you guys have an idea.
Currently stuck there.
@pgrandin if you could find your changes to see if you went at least this far, that would be great, thanks.
@jkoan other ideas?
Note: Dropped Ubuntu in favor to Debian as Ubuntu decided to drop the support for i386 architectures.
If you want to take over the PR, feel free to do so.