### PR TITLE
Reverting to the latest working update for the wince image

### DIFF
--- a/wince/Dockerfile
+++ b/wince/Dockerfile
@@ -1,22 +1,16 @@
-FROM i386/debian:stable
+FROM navit/ubuntu:8.04
 
-RUN apt-get update \
-# RUN dpkg --add-architecture i386 \
-#     && apt-get update \
-    && apt-get install -y --no-install-recommends wget libmpfr-dev gettext lcab \
-	ca-certificates zip ssh git-core xsltproc \
-    # cmake:i386 build-essential:i386 librsvg2-bin:i386 gcc:i386 binutils:i386 \
-    cmake build-essential librsvg2-bin gcc binutils \
+RUN apt-get update && apt-get install -y --no-install-recommends wget build-essential libmpfr-dev gettext pocketpc-cab \
+	ca-certificates zip ssh librsvg2-bin xsltproc \
 	 && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-COPY pocketpc-cab_1.0.1-2_all.deb /
-RUN dpkg -i /pocketpc-cab_1.0.1-2_all.deb \
-    && rm -f /pocketpc-cab_1.0.1-2_all.deb
 
 RUN wget -c http://cfhcable.dl.sourceforge.net/project/cegcc/cegcc/0.59.1/mingw32ce-0.59.1.tar.bz2 \
 	-O mingw32ce-0.59.1.tar.bz2 --no-check-certificate && tar xvjpf mingw32ce-0.59.1.tar.bz2 \
 	&& rm mingw32ce-0.59.1.tar.bz2
 
+RUN wget http://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-i386.sh --no-check-certificate && \
+	yes | bash /cmake-3.2.0-Linux-i386.sh --prefix /usr/local && rm /cmake-3.2.0-Linux-i386.sh
+
 RUN mkdir /var/lib/apt/lists/partial
 ENV MINGW32CE_PATH="/opt/mingw32ce"
-ENV PATH=$PATH:$MINGW32CE_PATH/bin
-
+ENV PATH=$PATH:$MINGW32CE_PATH/bin:/cmake-3.2.0-Linux-i386/bin/

--- a/wince/Dockerfile.1804
+++ b/wince/Dockerfile.1804
@@ -1,0 +1,22 @@
+FROM i386/debian:stable
+
+RUN apt-get update \
+# RUN dpkg --add-architecture i386 \
+#     && apt-get update \
+    && apt-get install -y --no-install-recommends wget libmpfr-dev gettext lcab \
+	ca-certificates zip ssh git-core xsltproc \
+    # cmake:i386 build-essential:i386 librsvg2-bin:i386 gcc:i386 binutils:i386 \
+    cmake build-essential librsvg2-bin gcc binutils \
+	 && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+COPY pocketpc-cab_1.0.1-2_all.deb /
+RUN dpkg -i /pocketpc-cab_1.0.1-2_all.deb \
+    && rm -f /pocketpc-cab_1.0.1-2_all.deb
+
+RUN wget -c http://cfhcable.dl.sourceforge.net/project/cegcc/cegcc/0.59.1/mingw32ce-0.59.1.tar.bz2 \
+	-O mingw32ce-0.59.1.tar.bz2 --no-check-certificate && tar xvjpf mingw32ce-0.59.1.tar.bz2 \
+	&& rm mingw32ce-0.59.1.tar.bz2
+
+RUN mkdir /var/lib/apt/lists/partial
+ENV MINGW32CE_PATH="/opt/mingw32ce"
+ENV PATH=$PATH:$MINGW32CE_PATH/bin
+


### PR DESCRIPTION
My changes broke the wince build so as long as we haven't finished to have a stable build, let's revert that change so that we don't break other people's PR checks.
I added the 18.04 version in a separate Dockerfile we can use to continue working on the upgrade in the meantime.